### PR TITLE
Finir maj en cours

### DIFF
--- a/modules/nouvelle_demande/js/myScript.js
+++ b/modules/nouvelle_demande/js/myScript.js
@@ -143,12 +143,46 @@ function maj_en_cours(o)
 					case "11":
 						name = "radioEtudiant"
 						$('#divEtudiantSub').show()
+				}
+			}
+			if(name == "id_cadre_sub_depl"){
+				switch (value){
+					case "1":
+					case "2":
+					case "3":
+					case "4":
+					case "5":
+					case "6":
+					case "7":
+					default:
+						name = "radioFormation"
+						$('#divFormationSub').show()
+						break; 
+					case "8":
+					case "9":
+					case "10":
+					case "11":
+					case "12":
+						name = "radioRecherche"
+						$('#divRechercheSub').show()
+						break;
+					case "13":
+					case "14":
+					case "15":
+					case "16":
+					case "17":
+						name = "radioAdministration"
+						$('#divAdministrationSub').show()
+				}
+			}
+			if(name == "cadre_depl"){
+				$("[name="+name+"][value="+value+"]").parent().parent().show();
 			}
 		}
 		$("[name="+name+"][value="+value+"]").prop('checked', true);
 	}
-	test = $('input[type=radio][name=radioPersonnel]:checked').length
-	alert(test)
+//	test = $('input[type=radio][name=radioPersonnel]:checked').length
+//	alert(test)
 	
 	
 	var limit = x.text.length;

--- a/modules/nouvelle_demande/js/myScript.js
+++ b/modules/nouvelle_demande/js/myScript.js
@@ -120,21 +120,32 @@ function maj_en_cours(o)
 		name = x.radio[i].name
 		value = x.radio[i].value
 		if(value != ""){
-			$("[name="+name+"][value="+value+"]").prop('checked', true);
-//
-//			$("[name="+name+"][value="+value+"]").parent().parent().show();
-//			$("[name="+name+"][value="+value+"]").parent().parent().parent().show();
+			if(name == "id_statut_sub_user"){
+				switch (value){
+					case "1":
+					case "2":
+					case "3":
+					case "4":
+					case "12":
+					default:
+						name = "radioPersonnel"
+						$('#divPersonnelSub').show()
+						break; 
+					case "5":
+					case "6":
+					case "7":
+						name = "radioApprenti"
+						$('#divApprentiSub').show()
+						break;
+					case "8":
+					case "9":
+					case "10":
+					case "11":
+						name = "radioEtudiant"
+						$('#divEtudiantSub').show()
+			}
 		}
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-//		if(test = $('input[type=radio][name=radioPersonnel]:checked').length == 1) alert(test)
-
-//		if($('input[type=radio][name=radioApprenti]:checked').length == 1) $('#divApprentiSub').show()
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-//		if($('input[type=radio][name=radioPersonnel]:checked').length == 1) $('#divPersonnelSub').show()
-
+		$("[name="+name+"][value="+value+"]").prop('checked', true);
 	}
 	test = $('input[type=radio][name=radioPersonnel]:checked').length
 	alert(test)


### PR DESCRIPTION
Lors de la consultation/modification d'une demande en cours de saisie, les boutons radios du statut d’utilisateur et du cadre du déplacement sont cochés et les div ad-hoc sont affichées.
